### PR TITLE
Set subscription ans subscription event report replication key to None

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-appstore"
-version = "0.0.1"
+version = "0.0.2"
 description = "`tap-appstore` is a Singer tap for AppStore, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Mahangu Weerasinghe <mahangu@automattic.com>"]

--- a/tap_appstore/streams.py
+++ b/tap_appstore/streams.py
@@ -110,6 +110,7 @@ class SubscriberReportStream(client.AppStoreStream):
 
 class SubscriptionReportStream(client.AppStoreStream):
     name = "subscription_report"
+    replication_key = None
     schema = th.PropertiesList(
         th.Property("_line_id", th.IntegerType),
         th.Property("_time_extracted", th.StringType),
@@ -170,6 +171,7 @@ class SubscriptionReportStream(client.AppStoreStream):
 
 class SubscriptionEventReportStream(client.AppStoreStream):
     name = "subscription_event_report"
+    replication_key = None
     schema = th.PropertiesList(
         th.Property("_line_id", th.IntegerType),
         th.Property("_time_extracted", th.StringType),


### PR DESCRIPTION
These streams need to be not incremental because the past reports can be updated and the singer SDK is failing when validating the current state id and the extracted value (raising and error informing that the data is not sorted).