### PR TITLE
Retry on every APIError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-appstore"
-version = "0.2.2"
+version = "0.2.3"
 description = "`tap-appstore` is a Singer tap for AppStore, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Mahangu Weerasinghe <mahangu@automattic.com>"]

--- a/tap_appstore/client.py
+++ b/tap_appstore/client.py
@@ -111,10 +111,7 @@ class AppStoreStream(Stream):
             if str(e).startswith('There were no') and str(e).endswith('for the date specified.') or str(e).startswith('Report is not available yet'):
                 logger.info(str(e))
                 return None
-            if ('Provide a properly configured and signed bearer token' in str(e) or
-                'This request requires an in-effect agreement' in str(e)):
-                raise RetriableAPIException(str(e))
-            raise
+            raise RetriableAPIException(str(e))
 
     @staticmethod
     def convert_date(date_str, date_format='%Y-%m-%d'):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -28,6 +28,7 @@ class TestAppStoreStream(unittest.TestCase):
         self.assertEqual(result, expected_result)
 
 
+@unittest.mock.patch('tenacity.nap.time.sleep', return_value=None)
 class TestGetReport(unittest.TestCase):
     """Tests for the _get_report method error handling."""
 
@@ -44,51 +45,50 @@ class TestGetReport(unittest.TestCase):
         # Call the undecorated method directly to avoid retry delays
         return AppStoreStream._get_report.__wrapped__(self.mock_stream, self.test_date)
 
-    def test_get_report_success(self):
+    def test_get_report_success(self, mock_sleep):
         """Test successful report download."""
         expected_data = "header1\theader2\nvalue1\tvalue2"
         self.mock_stream.download_data.return_value = expected_data
         result = AppStoreStream._get_report.__wrapped__(self.mock_stream, self.test_date)
         self.assertEqual(result, expected_data)
 
-    def test_get_report_no_data_for_date(self):
+    def test_get_report_no_data_for_date(self, mock_sleep):
         """Test APIError 'There were no... for the date specified.' returns None."""
         error = APIError("There were no sales for the date specified.")
         result = self._call_get_report(error)
         self.assertIsNone(result)
 
-    def test_get_report_not_available_yet(self):
+    def test_get_report_not_available_yet(self, mock_sleep):
         """Test APIError 'Report is not available yet' returns None."""
         error = APIError("Report is not available yet")
         result = self._call_get_report(error)
         self.assertIsNone(result)
 
-    def test_get_report_bearer_token_error_raises_retriable(self):
+    def test_get_report_bearer_token_error_raises_retriable(self, mock_sleep):
         """Test APIError with bearer token message raises RetriableAPIException."""
         error = APIError("Provide a properly configured and signed bearer token")
         with self.assertRaises(RetriableAPIException) as ctx:
             self._call_get_report(error)
         self.assertIn("bearer token", str(ctx.exception))
 
-    def test_get_report_agreement_error_raises_retriable(self):
+    def test_get_report_agreement_error_raises_retriable(self, mock_sleep):
         """Test APIError with agreement message raises RetriableAPIException."""
         error = APIError("This request requires an in-effect agreement that has not been signed")
         with self.assertRaises(RetriableAPIException) as ctx:
             self._call_get_report(error)
         self.assertIn("agreement", str(ctx.exception))
 
-    def test_get_report_other_api_error_reraises(self):
-        """Test other APIError messages are re-raised as APIError."""
+    def test_get_report_other_api_error_raises_retriable(self, mock_sleep):
+        """Test other APIError messages are converted to RetriableAPIException."""
         error = APIError("Some other API error")
-        with self.assertRaises(APIError) as ctx:
+        with self.assertRaises(RetriableAPIException) as ctx:
             self._call_get_report(error)
         self.assertEqual(str(ctx.exception), "Some other API error")
 
-    @unittest.mock.patch('tenacity.nap.time.sleep', return_value=None)
     def test_retriable_exception_triggers_retry(self, mock_sleep):
         """Test that RetriableAPIException triggers retry behavior."""
-        # Simulate: first 2 calls raise agreement error, third call succeeds
-        agreement_error = APIError("This request requires an in-effect agreement")
+        # Simulate: first 2 calls raise API error (converted to retriable), third call succeeds
+        api_error = APIError("Some API error")
         expected_data = "header1\theader2\nvalue1\tvalue2"
 
         call_count = 0
@@ -96,7 +96,7 @@ class TestGetReport(unittest.TestCase):
             nonlocal call_count
             call_count += 1
             if call_count < 3:
-                raise agreement_error
+                raise api_error
             return expected_data
 
         self.mock_stream.download_data.side_effect = side_effect
@@ -106,25 +106,6 @@ class TestGetReport(unittest.TestCase):
 
         self.assertEqual(result, expected_data)
         self.assertEqual(call_count, 3)  # Retried twice before succeeding
-
-    def test_api_error_does_not_retry(self):
-        """Test that APIError (non-retriable) does NOT trigger retry."""
-        error = APIError("Some permanent API error")
-
-        call_count = 0
-        def side_effect(*args, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            raise error
-
-        self.mock_stream.download_data.side_effect = side_effect
-
-        with self.assertRaises(APIError):
-            # Call the decorated method
-            AppStoreStream._get_report(self.mock_stream, self.test_date)
-
-        # Should only be called once - no retry for APIError
-        self.assertEqual(call_count, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request updates error handling in the AppStore client and improves the corresponding test coverage. The main change is that all `APIError` exceptions encountered in the `_get_report` method are now converted to `RetriableAPIException`, ensuring that any API errors will trigger retry behavior (as Apple server returns too many different errors on server side). The tests have been updated to reflect this change, removing the distinction between retriable and non-retriable API errors.

**Error handling changes:**

* All `APIError` exceptions in `client.py`'s `_get_report` method are now converted to `RetriableAPIException`, ensuring that all API errors trigger retries rather than being re-raised directly.

**Test updates:**

* Test cases in `tests/test_client.py` for `_get_report` have been updated so that any API error now expects a `RetriableAPIException`, and the previous test for non-retriable API errors has been removed. [[1]](diffhunk://#diff-0d92063e88430a02df61616c5f16b148b64ac4539d9cb9b8d883d5a23351b110L47-R99) [[2]](diffhunk://#diff-0d92063e88430a02df61616c5f16b148b64ac4539d9cb9b8d883d5a23351b110L110-L128)
* Added a patch for `tenacity.nap.time.sleep` to speed up test execution by skipping actual sleep calls during retry logic.

**Version bump:**

* Bumped the package version in `pyproject.toml` from `0.2.2` to `0.2.3` to reflect these changes.